### PR TITLE
Move automerge to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "module": "dist/manymerge.esm.js",
   "devDependencies": {
     "@types/jest": "^25.1.3",
+    "automerge": "^0.13.0",
     "husky": "^4.2.3",
     "tsdx": "^0.12.3",
     "tslib": "^1.11.1",
-    "typescript": "^3.8.3",
-    "automerge": "^0.13.0"
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "@types/events": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "husky": "^4.2.3",
     "tsdx": "^0.12.3",
     "tslib": "^1.11.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "automerge": "^0.13.0"
   },
   "dependencies": {
     "@types/events": "^3.0.0",
-    "automerge": "^0.13.0",
     "automerge-clocks": "1.2.1",
     "immutable": "^3.8.2",
     "invariant": "^2.2.4"


### PR DESCRIPTION
Automerge should be peerDep/devDep, not prod dependency. Otherwise, it can conflict with other automerge instances.