### PR TITLE
Synchronous fix

### DIFF
--- a/src/hub.test.ts
+++ b/src/hub.test.ts
@@ -253,7 +253,7 @@ test('We should only return something from applyMessage if we have a new doc', (
 });
 
 test('The hub works synchronously', () => {
-  type TestDoc = {title:string}
+  type TestDoc = { title: string };
 
   let hubDoc = init<TestDoc>();
   const peerById: { [peerId: string]: Peer } = {};
@@ -298,8 +298,8 @@ test('The hub works synchronously', () => {
     }
   });
 
-  peerDocById['peer1'] = change(peerDocById['peer1'], d => d.title = 'hello')
-  peerById['peer1'].notify(peerDocById['peer1'])
+  peerDocById['peer1'] = change(peerDocById['peer1'], d => (d.title = 'hello'));
+  peerById['peer1'].notify(peerDocById['peer1']);
 
   expect(hubDoc).toEqual(peerDocById['peer1']);
   expect(hubDoc).toEqual(peerDocById['peer2']);

--- a/src/hub.test.ts
+++ b/src/hub.test.ts
@@ -1,4 +1,4 @@
-import { change, from, getChanges, init } from 'automerge';
+import { change, from, getChanges, init, Doc } from 'automerge';
 import { getClock } from 'automerge-clocks';
 import { Map } from 'immutable';
 import { Hub } from './hub';
@@ -253,11 +253,13 @@ test('We should only return something from applyMessage if we have a new doc', (
 });
 
 test('The hub works synchronously', () => {
-  let hubDoc = init();
+  type TestDoc = {title:string}
+
+  let hubDoc = init<TestDoc>();
   const peerById: { [peerId: string]: Peer } = {};
-  const peerDocById: { [peerId: string]: any } = {
-    peer1: init(),
-    peer2: init(),
+  const peerDocById: { [peerId: string]: Doc<TestDoc> } = {
+    peer1: init<TestDoc>(),
+    peer2: init<TestDoc>(),
   };
 
   const hub = new Hub(
@@ -295,4 +297,10 @@ test('The hub works synchronously', () => {
       hubDoc = newDoc;
     }
   });
+
+  peerDocById['peer1'] = change(peerDocById['peer1'], d => d.title = 'hello')
+  peerById['peer1'].notify(peerDocById['peer1'])
+
+  expect(hubDoc).toEqual(peerDocById['peer1']);
+  expect(hubDoc).toEqual(peerDocById['peer2']);
 });

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -50,6 +50,12 @@ export class Hub {
 
     // 1. If they've sent us changes, we'll try to apply them.
     if (msg.changes) {
+      // We apply changes locally and update our clock before broadcasting.
+      // This way, in case the broadcast causes new messages to be delivered to us
+      // synchronously, our clock is uptodate.
+      ourDoc = applyChanges(doc, msg.changes);
+      this._ourClock = getClock(ourDoc);
+
       // We broadcast FIRST for the other members of the hub
       // Since we'll assume these changes should be applied to everyone.
       this.broadcastMsg({
@@ -60,9 +66,6 @@ export class Hub {
         // everyone else.
         changes: msg.changes,
       });
-
-      ourDoc = applyChanges(doc, msg.changes);
-      this._ourClock = getClock(ourDoc);
     }
 
     // 2. If we have any changes to let them know about,


### PR DESCRIPTION
Hi and thanks for this nice library!

Some of the tests in our own application connects peers and hubs in a synchrous way, i.e. `sendMsg` directly calls `applyMsg` of the other side. We do this because it makes the tests faster, and we don't need to rely on any networking.

We discovered that this results in infinite recursion because the hub will broadcast *before* it's updated its internal clock and therefore, its clock will be out of date when it immediately receives a new message from a peer.

This PR fixes this. Test attached.
